### PR TITLE
Installation fixes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-README.rst
-LICENSE
-AUTHORS
+include README.rst
+include LICENSE
+include AUTHORS

--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,5 @@ setup(
         author_email='emidln@gmail.com',
         url='https://github.com/pbs/haystack-cloudsearch',
         license='Apache License (2.0)',
-        py_modules=['haystack_cloudsearch'],
+        packages=['haystack_cloudsearch'],
 )


### PR DESCRIPTION
- Use "packages" in setup.py, so that the entire "haystack_cloudsearch" directory is installed.
- Fix syntax errors in MANIFEST.in.
